### PR TITLE
SystemUI: allow devices override audio panel location

### DIFF
--- a/packages/SystemUI/res/layout-land/volume_dialog.xml
+++ b/packages/SystemUI/res/layout-land/volume_dialog.xml
@@ -20,8 +20,6 @@
     android:id="@+id/volume_dialog_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="right"
-    android:layout_gravity="right"
     android:background="@android:color/transparent"
     android:theme="@style/volume_dialog_theme">
 
@@ -30,8 +28,6 @@
         android:id="@+id/volume_dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="right"
-        android:layout_gravity="right"
         android:layout_marginRight="@dimen/volume_dialog_panel_transparent_padding_right"
         android:orientation="vertical"
         android:clipToPadding="false"
@@ -43,8 +39,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:clipChildren="false"
-            android:gravity="right">
+            android:clipChildren="false">
 
             <include layout="@layout/volume_ringer_drawer" />
 

--- a/packages/SystemUI/res/layout/volume_dialog.xml
+++ b/packages/SystemUI/res/layout/volume_dialog.xml
@@ -20,8 +20,6 @@
     android:id="@+id/volume_dialog_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="right"
-    android:layout_gravity="right"
     android:clipToPadding="false"
     android:theme="@style/volume_dialog_theme">
 
@@ -30,8 +28,6 @@
         android:id="@+id/volume_dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="right"
-        android:layout_gravity="right"
         android:layout_marginRight="@dimen/volume_dialog_panel_transparent_padding_right"
         android:orientation="vertical"
         android:clipToPadding="false"
@@ -73,7 +69,6 @@
                 <include layout="@layout/volume_dnd_icon"
                          android:layout_width="match_parent"
                          android:layout_height="wrap_content"
-                         android:layout_marginRight="@dimen/volume_dialog_stream_padding"
                          android:layout_marginTop="6dp"/>
             </FrameLayout>
 
@@ -146,7 +141,6 @@
         android:layout="@layout/volume_tool_tip_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom | right"
         android:layout_marginRight="@dimen/volume_tool_tip_right_margin"/>
 
 </FrameLayout>

--- a/packages/SystemUI/res/values/fuse_config.xml
+++ b/packages/SystemUI/res/values/fuse_config.xml
@@ -11,8 +11,12 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- Whether usage of the proximity sensor during doze is supported -->
     <bool name="doze_proximity_sensor_supported">true</bool>
+
+    <!-- Allow devices override audio panel location to the left side -->
+    <bool name="config_audioPanelOnLeftSide">false</bool>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
@@ -78,6 +78,7 @@ import android.util.SparseBooleanArray;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.MotionEvent;
+import android.view.Gravity;
 import android.view.View;
 import android.view.View.AccessibilityDelegate;
 import android.view.View.OnAttachStateChangeListener;
@@ -254,6 +255,7 @@ public class VolumeDialogImpl implements VolumeDialog,
     private final boolean mUseBackgroundBlur;
     private Consumer<Boolean> mCrossWindowBlurEnabledListener;
     private BackgroundBlurDrawable mDialogRowsViewBackground;
+    private boolean mLeftVolumeRocker;
 
     public VolumeDialogImpl(Context context) {
         mContext =
@@ -290,6 +292,7 @@ public class VolumeDialogImpl implements VolumeDialog,
         }
 
         initDimens();
+        mLeftVolumeRocker = mContext.getResources().getBoolean(R.bool.config_audioPanelOnLeftSide);
     }
 
     @Override
@@ -390,7 +393,11 @@ public class VolumeDialogImpl implements VolumeDialog,
         lp.format = PixelFormat.TRANSLUCENT;
         lp.setTitle(VolumeDialogImpl.class.getSimpleName());
         lp.windowAnimations = -1;
-        lp.gravity = mContext.getResources().getInteger(R.integer.volume_dialog_gravity);
+        if(!isAudioPanelOnLeftSide()){
+            lp.gravity = Gravity.RIGHT | Gravity.CENTER_VERTICAL;
+        } else {
+            lp.gravity = Gravity.LEFT | Gravity.CENTER_VERTICAL;
+        }
         mWindow.setAttributes(lp);
         mWindow.setLayout(WRAP_CONTENT, WRAP_CONTENT);
 
@@ -400,7 +407,7 @@ public class VolumeDialogImpl implements VolumeDialog,
         mDialog.setCanceledOnTouchOutside(true);
         mDialog.setOnShowListener(dialog -> {
             mDialogView.getViewTreeObserver().addOnComputeInternalInsetsListener(this);
-            if (!isLandscape()) mDialogView.setTranslationX(mDialogView.getWidth() / 2.0f);
+            if (!isLandscape()) mDialogView.setTranslationX((mDialogView.getWidth() / 2.0f)*(isAudioPanelOnLeftSide() ? -1 : 1));
             mDialogView.setAlpha(0);
             mDialogView.animate()
                     .alpha(1)
@@ -526,6 +533,7 @@ public class VolumeDialogImpl implements VolumeDialog,
         if (mHasSeenODICaptionsTooltip && mODICaptionsTooltipViewStub != null) {
             mDialogView.removeView(mODICaptionsTooltipViewStub);
             mODICaptionsTooltipViewStub = null;
+        }else if (mODICaptionsTooltipViewStub != null){
         }
 
         mSettingsView = mDialog.findViewById(R.id.settings_container);
@@ -623,7 +631,11 @@ public class VolumeDialogImpl implements VolumeDialog,
         if (D.BUG) Slog.d(TAG, "Adding row for stream " + stream);
         VolumeRow row = new VolumeRow();
         initRow(row, stream, iconRes, iconMuteRes, important, defaultStream);
-        mDialogRowsView.addView(row.view);
+        if(!isAudioPanelOnLeftSide()){
+            mDialogRowsView.addView(row.view, 0);
+        } else {
+            mDialogRowsView.addView(row.view);
+        }
         mRows.add(row);
     }
 
@@ -633,7 +645,11 @@ public class VolumeDialogImpl implements VolumeDialog,
             final VolumeRow row = mRows.get(i);
             initRow(row, row.stream, row.iconRes, row.iconMuteRes, row.important,
                     row.defaultStream);
-            mDialogRowsView.addView(row.view);
+            if(!isAudioPanelOnLeftSide()){
+                mDialogRowsView.addView(row.view, 0);
+            } else {
+                mDialogRowsView.addView(row.view);
+            }
             updateVolumeRowH(row);
         }
     }
@@ -1320,7 +1336,7 @@ public class VolumeDialogImpl implements VolumeDialog,
 
                     hideRingerDrawer();
                 }, 50));
-        if (!isLandscape()) animator.translationX(mDialogView.getWidth() / 2.0f);
+        if (!isLandscape()) animator.translationX((mDialogView.getWidth() / 2.0f)*(isAudioPanelOnLeftSide() ? -1 : 1));
         animator.start();
         checkODICaptionsTooltip(true);
         mController.notifyVisible(false);
@@ -2193,6 +2209,10 @@ public class VolumeDialogImpl implements VolumeDialog,
             rescheduleTimeoutH();
             return super.onRequestSendAccessibilityEvent(host, child, event);
         }
+    }
+
+    private boolean isAudioPanelOnLeftSide() {
+        return mLeftVolumeRocker;
     }
 
     private static class VolumeRow {


### PR DESCRIPTION
Some devices have volume buttons on left side and it not fancy if volume panel will be at right side.
You can override panel location using overlay for SystemUI:

<!-- Allow devices override audio panel location to the left side -->
<bool name="config_audioPanelOnLeftSide">true</bool>

Also includes:

commit f25ce242d9d0ca29d663d79ccb74ebbed02144c3 (HEAD -> pie)
Author: Alex Cruz <alex@dirtyunicorns.com>
Date:   Fri Dec 21 22:08:52 2018 -0600

    Volume panel: Do the same with less

commit 80fd436c97cb0eda45bd488cdd3ce23b2d1ba141
Author: Kshitij Gupta <kshitijgm@gmail.com>
Date:   Wed Dec 26 15:46:18 2018 +0000

    VolumeDialogImpl: Fix animation direction logic

    - This behaviour was changed in https://github.com/PotatoProject/frameworks_base/commit/f6f78266d42188b2808a735d12b4bca0aa3fafd9
    - Correct animation direction for better UX

    Signed-off-by: Jagrav Naik <jagravnaik0@gmail.com>
    Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

DennySPb: adapt to A12

Change-Id: Ice8fe600b5ece5c4f4503c17bcdcc691b471a211
Signed-off-by: DennySPb <dennyspb@gmail.com>