### PR TITLE
base: Phone ringtone setting for Multi SIM device [1/3]

### DIFF
--- a/core/java/android/preference/RingtonePreference.java
+++ b/core/java/android/preference/RingtonePreference.java
@@ -33,6 +33,7 @@ import android.util.AttributeSet;
  * <p>
  * If the user chooses the "Default" item, the saved string will be one of
  * {@link System#DEFAULT_RINGTONE_URI},
+ * {@link System#DEFAULT_RINGTONE2_URI},
  * {@link System#DEFAULT_NOTIFICATION_URI}, or
  * {@link System#DEFAULT_ALARM_ALERT_URI}. If the user chooses the "Silent"
  * item, the saved string will be an empty string.

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4653,6 +4653,16 @@ public final class Settings {
         public static final String RINGTONE = "ringtone";
 
         /**
+         * Persistent store for the system-wide default ringtone for Slot2 URI.
+         *
+         * @see #RINGTONE
+         * @see #DEFAULT_RINGTONE2_URI
+         *
+         */
+        /** {@hide} */
+        public static final String RINGTONE2 = "ringtone2";
+
+        /**
          * A {@link Uri} that will point to the current default ringtone at any
          * given time.
          * <p>
@@ -4662,11 +4672,26 @@ public final class Settings {
          */
         public static final Uri DEFAULT_RINGTONE_URI = getUriFor(RINGTONE);
 
+        /**
+         * A {@link Uri} that will point to the current default ringtone for Slot2
+         * at any given time.
+         *
+         * @see #DEFAULT_RINGTONE_URI
+         *
+         */
+        /** {@hide} */
+        public static final Uri DEFAULT_RINGTONE2_URI = getUriFor(RINGTONE2);
+
         /** {@hide} */
         @Readable
         public static final String RINGTONE_CACHE = "ringtone_cache";
         /** {@hide} */
         public static final Uri RINGTONE_CACHE_URI = getUriFor(RINGTONE_CACHE);
+
+        /** {@hide} */
+        public static final String RINGTONE2_CACHE = "ringtone2_cache";
+        /** {@hide} */
+        public static final Uri RINGTONE2_CACHE_URI = getUriFor(RINGTONE2_CACHE);
 
         /**
          * Persistent store for the system-wide default notification sound.
@@ -5296,6 +5321,7 @@ public final class Settings {
             PUBLIC_SETTINGS.add(VOLUME_BLUETOOTH_SCO);
             PUBLIC_SETTINGS.add(VOLUME_ASSISTANT);
             PUBLIC_SETTINGS.add(RINGTONE);
+            PUBLIC_SETTINGS.add(RINGTONE2);
             PUBLIC_SETTINGS.add(NOTIFICATION_SOUND);
             PUBLIC_SETTINGS.add(ALARM_ALERT);
             PUBLIC_SETTINGS.add(TEXT_AUTO_REPLACE);
@@ -5397,6 +5423,7 @@ public final class Settings {
         public static final Map<String, String> CLONE_FROM_PARENT_ON_VALUE = new ArrayMap<>();
         static {
             CLONE_FROM_PARENT_ON_VALUE.put(RINGTONE, Secure.SYNC_PARENT_SOUNDS);
+            CLONE_FROM_PARENT_ON_VALUE.put(RINGTONE2, Secure.SYNC_PARENT_SOUNDS);
             CLONE_FROM_PARENT_ON_VALUE.put(NOTIFICATION_SOUND, Secure.SYNC_PARENT_SOUNDS);
             CLONE_FROM_PARENT_ON_VALUE.put(ALARM_ALERT, Secure.SYNC_PARENT_SOUNDS);
         }

--- a/media/java/android/media/RingtoneManager.java
+++ b/media/java/android/media/RingtoneManager.java
@@ -50,6 +50,7 @@ import android.provider.MediaStore;
 import android.provider.MediaStore.MediaColumns;
 import android.provider.Settings;
 import android.provider.Settings.System;
+import android.telephony.SubscriptionManager;
 import android.util.Log;
 
 import com.android.internal.database.SortCursor;
@@ -151,6 +152,7 @@ public class RingtoneManager {
      * for this {@link Uri}. If showing an item for "Default" (@see
      * {@link #EXTRA_RINGTONE_SHOW_DEFAULT}), this can also be one of
      * {@link System#DEFAULT_RINGTONE_URI},
+     * {@link System#DEFAULT_RINGTONE2_URI},
      * {@link System#DEFAULT_NOTIFICATION_URI}, or
      * {@link System#DEFAULT_ALARM_ALERT_URI} to have the "Default" item
      * checked.
@@ -164,7 +166,7 @@ public class RingtoneManager {
      * Given to the ringtone picker as a {@link Uri}. The {@link Uri} of the
      * ringtone to play when the user attempts to preview the "Default"
      * ringtone. This can be one of {@link System#DEFAULT_RINGTONE_URI},
-     * {@link System#DEFAULT_NOTIFICATION_URI}, or
+     * {@link System#DEFAULT_RINGTONE2_URI}, {@link System#DEFAULT_NOTIFICATION_URI}, or
      * {@link System#DEFAULT_ALARM_ALERT_URI} to have the "Default" point to
      * the current sound for the given default sound type. If you are showing a
      * ringtone picker for some other type of sound, you are free to provide any
@@ -203,7 +205,7 @@ public class RingtoneManager {
      * It will be one of:
      * <li> the picked ringtone,
      * <li> a {@link Uri} that equals {@link System#DEFAULT_RINGTONE_URI},
-     * {@link System#DEFAULT_NOTIFICATION_URI}, or
+     * {@link System#DEFAULT_RINGTONE2_URI}, {@link System#DEFAULT_NOTIFICATION_URI}, or
      * {@link System#DEFAULT_ALARM_ALERT_URI} if the default was chosen,
      * <li> null if the "Silent" item was picked.
      * 
@@ -777,8 +779,8 @@ public class RingtoneManager {
     /**
      * Gets the current default sound's {@link Uri}. This will give the actual
      * sound {@link Uri}, instead of using this, most clients can use
-     * {@link System#DEFAULT_RINGTONE_URI}.
-     * 
+     * {@link System#DEFAULT_RINGTONE_URI} or {@link System#DEFAULT_RINGTONE2_URI}.
+     *
      * @param context A context used for querying.
      * @param type The type whose default sound should be returned. One of
      *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
@@ -787,7 +789,27 @@ public class RingtoneManager {
      * @see #setActualDefaultRingtoneUri(Context, int, Uri)
      */
     public static Uri getActualDefaultRingtoneUri(Context context, int type) {
-        String setting = getSettingForType(type);
+        return getActualDefaultRingtoneUriBySlot(context, type,
+                SubscriptionManager.getDefaultVoicePhoneId());
+    }
+
+    /**
+     * Gets the current default sound's {@link Uri} by slotId. This will give the actual
+     * sound {@link Uri}, instead of using this, most clients can use
+     * {@link System#DEFAULT_RINGTONE_URI} or {@link System#DEFAULT_RINGTONE2_URI}.
+     *
+     * @param context A context used for querying.
+     * @param type The type whose default sound should be returned. One of
+     *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
+     *            {@link #TYPE_ALARM}.
+     * @param slotId The slotId whose default sound should be returned.
+     * @return A {@link Uri} pointing to the default sound for the sound type.
+     * @see #setActualDefaultRingtoneUriBySlot(Context, int, Uri, int)
+     *
+     * @hide
+     */
+    public static Uri getActualDefaultRingtoneUriBySlot(Context context, int type, int slotId) {
+        String setting = getSettingForTypeBySlot(type, slotId);
         if (setting == null) return null;
         final String uriString = Settings.System.getStringForUser(context.getContentResolver(),
                 setting, context.getUserId());
@@ -805,7 +827,7 @@ public class RingtoneManager {
     
     /**
      * Sets the {@link Uri} of the default sound for a given sound type.
-     * 
+     *
      * @param context A context used for querying.
      * @param type The type whose default sound should be set. One of
      *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
@@ -814,7 +836,26 @@ public class RingtoneManager {
      * @see #getActualDefaultRingtoneUri(Context, int)
      */
     public static void setActualDefaultRingtoneUri(Context context, int type, Uri ringtoneUri) {
-        String setting = getSettingForType(type);
+        setActualDefaultRingtoneUriBySlot(context, type, ringtoneUri,
+                SubscriptionManager.getDefaultVoicePhoneId());
+    }
+
+    /**
+     * Sets the {@link Uri} of the default sound by slotId for a given sound type.
+     *
+     * @param context A context used for querying.
+     * @param type The type whose default sound should be set. One of
+     *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
+     *            {@link #TYPE_ALARM}.
+     * @param ringtoneUri A {@link Uri} pointing to the default sound to set.
+     * @param slotId The slotId whose default sound should be set.
+     * @see #getActualDefaultRingtoneUriBySlot(Context, int, int)
+     *
+     * @hide
+     */
+    public static void setActualDefaultRingtoneUriBySlot(Context context, int type,
+                Uri ringtoneUri, int slotId) {
+        String setting = getSettingForTypeBySlot(type, slotId);
         if (setting == null) return;
 
         final ContentResolver resolver = context.getContentResolver();
@@ -832,7 +873,7 @@ public class RingtoneManager {
         // Stream selected ringtone into cache so it's available for playback
         // when CE storage is still locked
         if (ringtoneUri != null) {
-            final Uri cacheUri = getCacheForType(type, context.getUserId());
+            final Uri cacheUri = getCacheForTypeBySlot(type, context.getUserId(), slotId);
             try (InputStream in = openRingtone(context, ringtoneUri);
                     OutputStream out = resolver.openOutputStream(cacheUri)) {
                 FileUtils.copy(in, out);
@@ -957,9 +998,9 @@ public class RingtoneManager {
         }
     }
 
-    private static String getSettingForType(int type) {
+    private static String getSettingForTypeBySlot(int type, int slotId) {
         if ((type & TYPE_RINGTONE) != 0) {
-            return Settings.System.RINGTONE;
+            return slotId == 1 ? Settings.System.RINGTONE2 : Settings.System.RINGTONE;
         } else if ((type & TYPE_NOTIFICATION) != 0) {
             return Settings.System.NOTIFICATION_SOUND;
         } else if ((type & TYPE_ALARM) != 0) {
@@ -971,13 +1012,22 @@ public class RingtoneManager {
 
     /** {@hide} */
     public static Uri getCacheForType(int type) {
-        return getCacheForType(type, UserHandle.getCallingUserId());
+        return getCacheForTypeBySlot(type, UserHandle.getCallingUserId(),
+                SubscriptionManager.getDefaultVoicePhoneId());
     }
 
     /** {@hide} */
     public static Uri getCacheForType(int type, int userId) {
+        return getCacheForTypeBySlot(type, userId, SubscriptionManager.getDefaultVoicePhoneId());
+    }
+
+    /** {@hide} */
+    public static Uri getCacheForTypeBySlot(int type, int userId, int slotId) {
         if ((type & TYPE_RINGTONE) != 0) {
-            return ContentProvider.maybeAddUserId(Settings.System.RINGTONE_CACHE_URI, userId);
+            Uri ringtoneUri = slotId == 1
+                    ? Settings.System.RINGTONE2_CACHE_URI
+                    : Settings.System.RINGTONE_CACHE_URI;
+            return ContentProvider.maybeAddUserId(ringtoneUri, userId);
         } else if ((type & TYPE_NOTIFICATION) != 0) {
             return ContentProvider.maybeAddUserId(Settings.System.NOTIFICATION_SOUND_CACHE_URI,
                     userId);
@@ -1002,6 +1052,7 @@ public class RingtoneManager {
      * 
      * @param defaultRingtoneUri The default {@link Uri}. For example,
      *            {@link System#DEFAULT_RINGTONE_URI},
+     *            {@link System#DEFAULT_RINGTONE2_URI},
      *            {@link System#DEFAULT_NOTIFICATION_URI}, or
      *            {@link System#DEFAULT_ALARM_ALERT_URI}.
      * @return The type of the defaultRingtoneUri, or -1.
@@ -1010,7 +1061,8 @@ public class RingtoneManager {
         defaultRingtoneUri = ContentProvider.getUriWithoutUserId(defaultRingtoneUri);
         if (defaultRingtoneUri == null) {
             return -1;
-        } else if (defaultRingtoneUri.equals(Settings.System.DEFAULT_RINGTONE_URI)) {
+        } else if (defaultRingtoneUri.equals(Settings.System.DEFAULT_RINGTONE_URI)
+                    || defaultRingtoneUri.equals(Settings.System.DEFAULT_RINGTONE2_URI)) {
             return TYPE_RINGTONE;
         } else if (defaultRingtoneUri.equals(Settings.System.DEFAULT_NOTIFICATION_URI)) {
             return TYPE_NOTIFICATION;
@@ -1026,13 +1078,31 @@ public class RingtoneManager {
      * Rather than returning the actual ringtone's sound {@link Uri}, this will
      * return the symbolic {@link Uri} which will resolved to the actual sound
      * when played.
-     * 
+     *
      * @param type The ringtone type whose default should be returned.
      * @return The {@link Uri} of the default ringtone for the given type.
      */
     public static Uri getDefaultUri(int type) {
+        return getDefaultUriBySlot(type, SubscriptionManager.getDefaultVoicePhoneId());
+    }
+
+    /**
+     * Returns the {@link Uri} for the default ringtone by slotId of a particular type.
+     * Rather than returning the actual ringtone's sound {@link Uri}, this will
+     * return the symbolic {@link Uri} which will resolved to the actual sound
+     * when played.
+     *
+     * @param type The ringtone type whose default should be returned.
+     * @param slotId The slotId whose default should be returned.
+     * @return The {@link Uri} of the default ringtone for the given type.
+     *
+     * @hide
+     */
+    public static Uri getDefaultUriBySlot(int type, int slotId) {
         if ((type & TYPE_RINGTONE) != 0) {
-            return Settings.System.DEFAULT_RINGTONE_URI;
+            return slotId == 1
+                    ? Settings.System.DEFAULT_RINGTONE2_URI
+                    : Settings.System.DEFAULT_RINGTONE_URI;
         } else if ((type & TYPE_NOTIFICATION) != 0) {
             return Settings.System.DEFAULT_NOTIFICATION_URI;
         } else if ((type & TYPE_ALARM) != 0) {

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsHelper.java
@@ -165,6 +165,7 @@ public class SettingsHelper {
             } else if (isAlreadyConfiguredCriticalAccessibilitySetting(name)) {
                 return;
             } else if (Settings.System.RINGTONE.equals(name)
+                    || Settings.System.RINGTONE2.equals(name)
                     || Settings.System.NOTIFICATION_SOUND.equals(name)
                     || Settings.System.ALARM_ALERT.equals(name)) {
                 setRingtone(name, value);
@@ -228,11 +229,12 @@ public class SettingsHelper {
 
     public String onBackupValue(String name, String value) {
         // Special processing for backing up ringtones & notification sounds
-        if (Settings.System.RINGTONE.equals(name)
+        if (Settings.System.RINGTONE.equals(name) || Settings.System.RINGTONE2.equals(name)
                 || Settings.System.NOTIFICATION_SOUND.equals(name)
                 || Settings.System.ALARM_ALERT.equals(name)) {
             if (value == null) {
-                if (Settings.System.RINGTONE.equals(name)) {
+                if (Settings.System.RINGTONE.equals(name)
+                        || Settings.System.RINGTONE2.equals(name)) {
                     // For ringtones, we need to distinguish between non-telephony vs telephony
                     if (mTelephonyManager != null && mTelephonyManager.isVoiceCapable()) {
                         // Backup a null ringtone as silent on voice-capable devices
@@ -282,7 +284,7 @@ public class SettingsHelper {
     /**
      * Sets the ringtone of type specified by the name.
      *
-     * @param name should be Settings.System.RINGTONE, Settings.System.NOTIFICATION_SOUND
+     * @param name should be Settings.System.RINGTONE, Settings.System.RINGTONE2, Settings.System.NOTIFICATION_SOUND
      * or Settings.System.ALARM_ALERT.
      * @param value can be a canonicalized uri or "_silent" to indicate a silent (null) ringtone.
      */
@@ -308,6 +310,8 @@ public class SettingsHelper {
     private int getRingtoneType(String name) {
         switch (name) {
             case Settings.System.RINGTONE:
+                return RingtoneManager.TYPE_RINGTONE;
+            case Settings.System.RINGTONE2:
                 return RingtoneManager.TYPE_RINGTONE;
             case Settings.System.NOTIFICATION_SOUND:
                 return RingtoneManager.TYPE_NOTIFICATION;

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java
@@ -2799,7 +2799,13 @@ class SettingsProtoDumpUtil {
                 Settings.System.RINGTONE,
                 SystemSettingsProto.Ringtone.DEFAULT_URI);
         dumpSetting(s, p,
+                Settings.System.RINGTONE2,
+                SystemSettingsProto.Ringtone.DEFAULT_URI);
+        dumpSetting(s, p,
                 Settings.System.RINGTONE_CACHE,
+                SystemSettingsProto.Ringtone.CACHE);
+        dumpSetting(s, p,
+                Settings.System.RINGTONE2_CACHE,
                 SystemSettingsProto.Ringtone.CACHE);
         p.end(ringtoneToken);
 

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -818,6 +818,9 @@ public class SettingsProvider extends ContentProvider {
         if (Settings.System.RINGTONE_CACHE_URI.equals(uri)) {
             cacheRingtoneSetting = Settings.System.RINGTONE;
             cacheName = Settings.System.RINGTONE_CACHE;
+        } else if (Settings.System.RINGTONE2_CACHE_URI.equals(uri)) {
+            cacheRingtoneSetting = Settings.System.RINGTONE2;
+            cacheName = Settings.System.RINGTONE2_CACHE;
         } else if (Settings.System.NOTIFICATION_SOUND_CACHE_URI.equals(uri)) {
             cacheRingtoneSetting = Settings.System.NOTIFICATION_SOUND;
             cacheName = Settings.System.NOTIFICATION_SOUND_CACHE;
@@ -1880,6 +1883,8 @@ public class SettingsProvider extends ContentProvider {
         String cacheName = null;
         if (Settings.System.RINGTONE.equals(name)) {
             cacheName = Settings.System.RINGTONE_CACHE;
+        } else if (Settings.System.RINGTONE2.equals(name)) {
+            cacheName = Settings.System.RINGTONE2_CACHE;
         } else if (Settings.System.NOTIFICATION_SOUND.equals(name)) {
             cacheName = Settings.System.NOTIFICATION_SOUND_CACHE;
         } else if (Settings.System.ALARM_ALERT.equals(name)) {


### PR DESCRIPTION
Add below changes to handle default phone ringtone for slot2.
1. Add Settings.System.RINGTONE2 as the key in SettingsProvider to
save ringtone for slot2.
2. Support "ro.config.ringtone" for Multi SIM device.
3. Adapt ringtone for slot2 in current ringtone related APIs.

Bug: 118735436
Test: Manual
Change-Id: I9c6ccff938122332d222853d469ad9a623c7d193